### PR TITLE
Agent Register & Lifecycle

### DIFF
--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1,0 +1,77 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	agentv1 "github.com/aero-arc/aero-arc-protos/gen/go/aeroarc/agent/v1"
+	"google.golang.org/grpc"
+)
+
+func TestNextBackoff(t *testing.T) {
+	tests := []struct {
+		current, max time.Duration
+		want         time.Duration
+	}{
+		{current: time.Second, max: 10 * time.Second, want: 2 * time.Second},
+		{current: 8 * time.Second, max: 10 * time.Second, want: 10 * time.Second},
+		{current: 20 * time.Second, max: 10 * time.Second, want: 10 * time.Second},
+	}
+
+	for _, tc := range tests {
+		if got := nextBackoff(tc.current, tc.max); got != tc.want {
+			t.Fatalf("nextBackoff(%v, %v) = %v, want %v", tc.current, tc.max, got, tc.want)
+		}
+	}
+}
+
+func TestRunWithReconnect_DialFailureHonorsContextAndBackoff(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	a := &Agent{
+		options:        &AgentOptions{RelayTarget: "test:1234"},
+		backoffInitial: 5 * time.Millisecond,
+		backoffMax:     10 * time.Millisecond,
+	}
+
+	var dialCalls, sleepCalls int
+
+	a.dialFn = func(ctx context.Context) (*grpc.ClientConn, error) {
+		dialCalls++
+		return nil, errors.New("dial failed")
+	}
+	a.registerFn = func(ctx context.Context) error {
+		t.Fatalf("register should not be called on dial failure")
+		return nil
+	}
+	a.openStreamFn = func(ctx context.Context) (grpc.BidiStreamingClient[agentv1.TelemetryFrame, agentv1.TelemetryAck], error) {
+		t.Fatalf("openStreamFn should not be called on dial failure")
+		return nil, nil
+	}
+	a.streamLoopFn = func(ctx context.Context, _ grpc.BidiStreamingClient[agentv1.TelemetryFrame, agentv1.TelemetryAck]) error {
+		t.Fatalf("streamLoopFn should not be called on dial failure")
+		return nil
+	}
+	a.sleepWithBack = func(c context.Context, d time.Duration) bool {
+		sleepCalls++
+		// Simulate shutdown after first backoff.
+		cancel()
+		return false
+	}
+
+	err := a.runWithReconnect(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if dialCalls == 0 {
+		t.Fatalf("expected at least one dial attempt")
+	}
+	if sleepCalls != 1 {
+		t.Fatalf("expected exactly one sleep/backoff, got %d", sleepCalls)
+	}
+}
+
+

--- a/internal/agent/errors.go
+++ b/internal/agent/errors.go
@@ -3,16 +3,17 @@ package agent
 import "errors"
 
 var (
-	ErrSerialPathNotSet        = errors.New("serial path not set")
-	ErrSerialBaudNotSet        = errors.New("serial baud not set")
-	ErrServerAddressNotSet     = errors.New("server address not set")
-	ErrServerPortNotSet        = errors.New("server port not set")
-	ErrConsulAddressNotSet     = errors.New("consul address not set")
-	ErrConsulPortNotSet        = errors.New("consul port not set")
-	ErrConsulTokenNotSet       = errors.New("consul token not set")
-	ErrConsulAgentIDNotSet     = errors.New("consul agent ID not set")
-	ErrConsulUnsupported       = errors.New("consul unsupported")
-	ErrFailedToConnectToServer = errors.New("failed to connect to server")
+	ErrSerialPathNotSet          = errors.New("serial path not set")
+	ErrSerialBaudNotSet          = errors.New("serial baud not set")
+	ErrServerAddressNotSet       = errors.New("server address not set")
+	ErrServerPortNotSet          = errors.New("server port not set")
+	ErrConsulAddressNotSet       = errors.New("consul address not set")
+	ErrConsulPortNotSet          = errors.New("consul port not set")
+	ErrConsulTokenNotSet         = errors.New("consul token not set")
+	ErrConsulAgentIDNotSet       = errors.New("consul agent ID not set")
+	ErrConsulUnsupported         = errors.New("consul unsupported")
+	ErrFailedToConnectToServer   = errors.New("failed to connect to server")
+	ErrFailedRelayGrpcConnection = errors.New("failed to establish relay grpc connection")
 
 	ErrGatewayNotInitialized = errors.New("agent gateway client not initialized")
 )


### PR DESCRIPTION
## Summary

This PR refactors the AeroArc Agent’s registration and gRPC lifecycle handling, centralizing connection management in `runWithReconnect` and wiring the agent’s stable identity into the registration flow.

## Changes

### 1. Identity-aware registration

- `internal/agent/agent.go`
  - `Start` now resolves the agent identity once at startup using `identity.Resolve()` and logs the `FinalID`.
  - `register` now populates `agentv1.RegisterRequest.AgentId` with `identity.Resolve().FinalID`, so each agent instance registers with a stable, installation-level identity.

### 2. Simplified gRPC connection + stream lifecycle

- `runWithReconnect` has been reworked into a clear state machine that **owns the full lifecycle** of the gRPC connection and telemetry stream:
  1. **Dial** the relay via `establishRelayConnection`, with a timeout and structured logging on failure.
  2. **Register** with the relay using a 10s timeout; on failure:
     - Log the error.
     - Close the connection.
     - Sleep with exponential backoff (bounded by `backoffMax`).
     - Retry unless the context is cancelled.
  3. **Open telemetry stream** via `openTelemetryStream`; on failure:
     - Log the error.
     - Close the connection.
     - Sleep with backoff and retry.
  4. **Run stream loop** via `runStreamLoop` until:
     - The stream errors, or
     - The context is cancelled.
     - On exit, log `"agent_stream_closed"`, close the stream and connection, and reset `backoff` to the initial value.
  5. If there was a stream error and the context is still active:
     - Log `"agent_stream_error"`.
     - Sleep with backoff and retry from step 1.

- This consolidates previously scattered responsibilities (dialing, registering, streaming, and reconnecting) into a single, easy-to-reason-about loop that:
  - Respects `context.Context` for shutdown,
  - Cleans up connections/streams on all paths,
  - Uses exponential backoff consistently across dial, register, and stream failures.

## Rationale

- **Stable identity in registration**: The backend needs a stable identifier per agent installation; using `identity.Resolve().FinalID` ensures every register call is tied to that identity.
- **Lifecycle clarity**: Having one place (`runWithReconnect`) own `dial → register → stream → teardown → backoff → retry` makes reconnect behavior predictable and maintainable.
- **Operational safety**: Context-aware backoff and explicit teardown reduce the risk of leaking connections or spinning aggressively on network/server failures.

## Testing

- `go test ./...`:
  - `internal/agent` compiles successfully.
  - Identity and supporting packages still pass their tests.
- Manual reasoning/inspection of `runWithReconnect`:
  - Verified all error paths log, clean up (`stream.CloseSend`, `conn.Close`), and either retry with backoff or exit cleanly when the context is cancelled.