### PR TITLE
[Agent] Introduce Debug Flag

### DIFF
--- a/cmd/aero-arc-agent/main.go
+++ b/cmd/aero-arc-agent/main.go
@@ -60,10 +60,14 @@ var agentCmd = cli.Command{
 			Usage: "Skip TLS verification",
 		},
 		&cli.StringFlag{
-			Name:     "wal-path",
-			Value:    "agent_wal.db",
-			Required: true,
-			Usage:    "Path to the Write-Ahead Log (SQLite) file (required)",
+			Name:  "wal-path",
+			Value: "agent_wal.db",
+			Usage: "Path to the Write-Ahead Log (SQLite) file (required)",
+		},
+		&cli.BoolFlag{
+			Name:  "debug",
+			Value: false,
+			Usage: "Enable debug mode. Mainly used for sim testing.",
 		},
 	},
 }

--- a/internal/agent/options.go
+++ b/internal/agent/options.go
@@ -30,21 +30,10 @@ type AgentOptions struct {
 	EventQueueSize      int
 	SkipTLSVerification bool
 	WALPath             string
+	Debug               bool
 }
 
 func GetAgentOptions(c *cli.Command) (*AgentOptions, error) {
-	if !c.IsSet("serial-path") {
-		return nil, ErrSerialPathNotSet
-	}
-	if !c.IsSet("serial-baud") {
-		return nil, ErrSerialBaudNotSet
-	}
-	if !c.IsSet("server-address") {
-		return nil, ErrServerAddressNotSet
-	}
-	if !c.IsSet("server-port") {
-		return nil, ErrServerPortNotSet
-	}
 	if c.IsSet("consul-address") || c.IsSet("consul-port") || c.IsSet("consul-token") || c.IsSet("consul-agent-id") {
 		return nil, ErrConsulUnsupported
 	}
@@ -62,5 +51,6 @@ func GetAgentOptions(c *cli.Command) (*AgentOptions, error) {
 		EventQueueSize:      c.Int("event-queue-size"),
 		WALPath:             c.String("wal-path"),
 		SkipTLSVerification: c.Bool("skip-tls-verification"),
+		Debug:               c.Bool("debug"),
 	}, nil
 }


### PR DESCRIPTION
This PR introduces a `--debug` flag into the agent for testing with sitl. This allows us to optionally start a grpc client with insecure credentials to interact with local instances of the relay. We also will start a gomavlib UDPServer to interact with ardupilot's sitl + mavproxy.

```
makinje@Roxas:~/aero-arc-agent$ bin/aero-arc-agent --help
NAME:
   run - run the agent edge process

USAGE:
   run [global options]

GLOBAL OPTIONS:
   --serial-path string        The serial path to use for the agent (default: "/dev/ttyUSB0")
   --serial-baud int           The baud rate to use for the serial connection (default: 115200)
   --server-address string     The address of the server to connect to (default: "localhost")
   --server-port int           The port of the server to connect to (default: 8080)
   --backoff-initial duration  Initial reconnect backoff duration (default: 1s)
   --backoff-max duration      Maximum reconnect backoff duration (default: 30s)
   --event-queue-size int      The size of the event queue (default: 1000)
   --skip-tls-verification     Skip TLS verification
   --wal-path string           Path to the Write-Ahead Log (SQLite) file (required) (default: "agent_wal.db")
   --debug                     Enable debug mode. Mainly used for sim testing.
   --help, -h                  show help
makinje@Roxas:~/aero-arc-agent$ 
```