### PR TITLE
[WAL] Implement Batched Telemetry Ingestion to WAL

### DIFF
--- a/cmd/aero-arc-agent/main.go
+++ b/cmd/aero-arc-agent/main.go
@@ -69,6 +69,16 @@ var agentCmd = cli.Command{
 			Value: false,
 			Usage: "Enable debug mode. Mainly used for sim testing.",
 		},
+		&cli.Int64Flag{
+			Name:  "wal-batch-size",
+			Value: 1000,
+			Usage: "WAL write batch size",
+		},
+		&cli.DurationFlag{
+			Name:  "wal-flush-timeout",
+			Value: time.Second * 10,
+			Usage: "WAL flush interval if batch queue doesn't fill up",
+		},
 	},
 }
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -112,7 +112,7 @@ func (a *Agent) Start(ctx context.Context, sig <-chan os.Signal) error {
 	slog.LogAttrs(ctx, slog.LevelInfo, "agent_identity", slog.String("identity", identity.FinalID))
 
 	// Initialize WAL
-	w, err := wal.New(a.options.WALPath)
+	w, err := wal.New(a.options.WALPath, a.options.WALBatchSize, a.options.WALFlushTimeout)
 	if err != nil {
 		return fmt.Errorf("failed to initialize WAL: %w", err)
 	}
@@ -269,7 +269,7 @@ func (a *Agent) sendToWAL(ctx context.Context, frame *gomavlib.EventFrame) (*age
 	if err != nil {
 		return nil, fmt.Errorf("wal append failed: %w", err)
 	}
-	//TODO: fix this conversion. Should it be int64 or uint64?
+	// TODO: fix this conversion. Should it be int64 or uint64?
 	tFrame.Seq = uint64(id)
 
 	return tFrame, nil
@@ -376,7 +376,6 @@ func (a *Agent) openTelemetryStream(ctx context.Context) (grpc.BidiStreamingClie
 // runStreamLoop handles the receive side of the telemetry stream. Outbound
 // sends will be wired in a later iteration once the queue is implemented.
 func (a *Agent) runAckLoop(ctx context.Context, stream grpc.BidiStreamingClient[agentv1.TelemetryFrame, agentv1.TelemetryAck]) error {
-
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/agent/options.go
+++ b/internal/agent/options.go
@@ -30,6 +30,8 @@ type AgentOptions struct {
 	EventQueueSize      int
 	SkipTLSVerification bool
 	WALPath             string
+	WALBatchSize        int64
+	WALFlushTimeout     time.Duration
 	Debug               bool
 }
 
@@ -50,6 +52,8 @@ func GetAgentOptions(c *cli.Command) (*AgentOptions, error) {
 		APIKey:              os.Getenv("AERO_ARC_API_KEY"),
 		EventQueueSize:      c.Int("event-queue-size"),
 		WALPath:             c.String("wal-path"),
+		WALBatchSize:        c.Int64("wal-batch-size"),
+		WALFlushTimeout:     c.Duration("wal-flush-timeout"),
 		SkipTLSVerification: c.Bool("skip-tls-verification"),
 		Debug:               c.Bool("debug"),
 	}, nil

--- a/internal/wal/wal.go
+++ b/internal/wal/wal.go
@@ -592,7 +592,13 @@ func (w *WAL) ResetPending(ctx context.Context, ttl time.Duration) (int64, error
 		return 0, fmt.Errorf("failed to reset pending frames: %w", err)
 	}
 
-	return res.RowsAffected()
+	rows, err := res.RowsAffected()
+
+	if rows != 0 {
+		w.signalChan <- struct{}{}
+	}
+
+	return rows, err
 }
 
 // CleanupDelivered deletes delivered frames that are older than the specified retention count.


### PR DESCRIPTION
## Summary
This PR introduces batching for telemetry ingestion into the Write-Ahead Log (WAL). Instead of writing each telemetry frame to SQLite synchronously (which triggers an `fsync` for every event), we now buffer frames and write them in bulk transactions.

## Motivation
High-frequency telemetry ingestion was causing significant database contention and deadlocks.
- **Current Behavior**: Every MAVLink event triggers a single-row `INSERT` transaction with `PRAGMA synchronous=FULL`. This results in excessive disk I/O (fsyncs) and lock contention on the single-writer SQLite database.
- **Problem**: Under load, the `wal.Append` calls block, slowing down the ingestion loop and occasionally deadlocking when reader/writer threads compete.

## Proposed Changes

### 1. Update WAL Package (`internal/wal`)
- **Add `AppendBatch` method**:
  - Accepts a slice of `*agentv1.TelemetryFrame`.
  - Wraps all inserts in a single SQLite transaction (`BeginTx` -> `Prepare` -> Loop -> `Commit`).
  - Ensures atomic writes: either the whole batch is saved, or none of it is (on error).
  - Significantly reduces `fsync` calls (1 per batch vs. 1 per frame).

- **Add Batching Configuration**:
  - Introduce internal buffering logic (likely via a `batchSize` and `batchTimeout` config in the WAL struct).
  - Implement a background worker or async method to accumulate frames before triggering `AppendBatch`.

### 2. Update Agent Ingestion (`internal/agent`)
- Modify the ingestion flow to utilize the new batching capability.
- (Optional/Architectural shift) Decouple the "Send to WAL" logic from the "Send to Stream" logic to handle the asynchronous nature of batch writes, ensuring frames sent to the relay have valid, durable Sequence IDs generated by the DB.

## Benefits
- **Performance**: Drastically reduces disk I/O overhead.
- **Stability**: Eliminates the database lock contention and deadlocks observed during high-throughput ingestion.
- **Durability**: Maintains data safety properties while improving throughput.