### PR TITLE
[Agent] Add Telemetry Stats and Logging

### DIFF
--- a/internal/agent/telemetry_stats.go
+++ b/internal/agent/telemetry_stats.go
@@ -1,0 +1,63 @@
+package agent
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+func (a *Agent) runTelemetryStats(ctx context.Context, interval time.Duration) {
+	if interval <= 0 {
+		return
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	lastIngest := uint64(0)
+	lastSent := uint64(0)
+	last := time.Now()
+
+	for {
+		select {
+		case <-ticker.C:
+			if a.wal == nil {
+				continue
+			}
+			now := time.Now()
+			elapsed := now.Sub(last).Seconds()
+			if elapsed <= 0 {
+				last = now
+				continue
+			}
+
+			ingestTotal := a.ingestCount.Load()
+			sentTotal := a.sendCount.Load()
+
+			ingestRate := float64(ingestTotal-lastIngest) / elapsed
+			sendRate := float64(sentTotal-lastSent) / elapsed
+
+			lastIngest = ingestTotal
+			lastSent = sentTotal
+			last = now
+
+			undelivered, err := a.wal.CountUndelivered(ctx)
+			if err != nil {
+				slog.LogAttrs(ctx, slog.LevelWarn, "telemetry_stats_wal_count_error", slog.String("error", err.Error()))
+			}
+
+			slog.LogAttrs(
+				ctx, slog.LevelInfo,
+				"telemetry_stats",
+				slog.Float64("ingest_rate_per_s", ingestRate),
+				slog.Float64("send_rate_per_s", sendRate),
+				slog.Int64("undelivered_count", undelivered),
+				slog.Uint64("ingest_total", ingestTotal),
+				slog.Uint64("sent_total", sentTotal),
+				slog.Float64("interval_s", elapsed),
+			)
+		case <-ctx.Done():
+			return
+		}
+	}
+}

--- a/internal/wal/wal.go
+++ b/internal/wal/wal.go
@@ -488,6 +488,20 @@ func (w *WAL) ReadUndelivered(ctx context.Context, limit int) ([]Entry, error) {
 	return entries, nil
 }
 
+// CountUndelivered returns the total number of undelivered entries.
+func (w *WAL) CountUndelivered(ctx context.Context) (int64, error) {
+	query := `
+	SELECT COUNT(1)
+	FROM telemetry_frames
+	WHERE delivery_status = ?
+	`
+	var count int64
+	if err := w.db.QueryRowContext(ctx, query, DeliveryStatusWritten).Scan(&count); err != nil {
+		return 0, fmt.Errorf("failed to count undelivered frames: %w", err)
+	}
+	return count, nil
+}
+
 // WaitForData blocks until new data is signaled or the context is cancelled.
 func (w *WAL) WaitForData(ctx context.Context) error {
 	select {


### PR DESCRIPTION
## Description
This PR introduces new logging to determine agent mavlink ingestion rate, the send rate to the relay, and the number of undelivered messages

## Why
We want to be able to see if our current architecture keeps up with the rate at which MAVLink is sending data. This allows us to see how far behind we are in emitting telemetry. Future work would be to push this data to a prom gateway server so it can be scraped and displayed in a dashboard. Allowing operators to see how far behind we are in reading telemetry data.

## Testing
- [x] Over two hours of continuous running. No errors. Logs show ingestion and send rate
```
94359 send_rate_per_s=110.81267606147749 undelivered_count=0 ingest_total=785596 sent_total=788033 interval_s=9.998856082
2026/01/02 16:21:39 INFO telemetry_stats ingest_rate_per_s=111.200011620
40121 send_rate_per_s=120.4000125818013 undelivered_count=0 ingest_total=786708 sent_total=789237 interval_s=9.999998955
2026/01/02 16:21:48 INFO telemetry_stats ingest_rate_per_s=111.109382387
35507 send_rate_per_s=110.40932327240323 undelivered_count=0 ingest_total=787819 sent_total=790341 interval_s=9.999155572
```