### PR TITLE
[Makefile] Add Local TLS Certs Target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-.PHONY: build build-all run test test-coverage test-race test-all clean docker-build docker-run docker-stop logs help lint fmt vet race coverage bench install-tools ci staticcheck quality security deps-graph deps docs dev pre-commit release local-ssh-keys
+.PHONY: build build-all run test test-coverage test-race test-all clean docker-build docker-run docker-stop logs help lint fmt vet race coverage bench install-tools ci staticcheck quality security deps-graph deps docs dev pre-commit release local-tls-certs
 
 # Variables
 
@@ -204,16 +204,16 @@ release: clean build-all test-all quality security
 
 # Generate local TLS certs for development
 # https://letsencrypt.org/docs/certificates-for-localhost/
-local-ssh-keys:
-	@if [ -f ~/.aeroarc/local-keys/localhost.crt ] && [ -f ~/.aeroarc/local-keys/localhost.key ]; then \
-		echo "Local TLS certs already exist at ~/.aeroarc/local-keys."; \
+local-tls-certs:
+	@if [ -f ~/.aeroarc/local-certs/localhost.crt ] && [ -f ~/.aeroarc/local-keys/localhost.key ]; then \
+		echo "Local TLS certs already exist at ~/.aeroarc/local-certs."; \
 	else \
-		mkdir -p ~/.aeroarc/local-keys; \
-		openssl req -x509 -out ~/.aeroarc/local-keys/localhost.crt -keyout ~/.aeroarc/local-keys/localhost.key \
+		mkdir -p ~/.aeroarc/local-certs; \
+		openssl req -x509 -out ~/.aeroarc/local-certs/localhost.crt -keyout ~/.aeroarc/local-keys/localhost.key \
 			-newkey rsa:2048 -nodes -sha256 \
 			-subj '/CN=localhost' -extensions EXT -config <( \
 				printf "[dn]\nCN=localhost\n[req]\ndistinguished_name = dn\n[EXT]\nsubjectAltName=DNS:localhost\nkeyUsage=digitalSignature\nextendedKeyUsage=serverAuth"); \
-		echo "Local TLS certs generated in ~/.aeroarc/local-keys."; \
+		echo "Local TLS certs generated in ~/.aeroarc/local-certs."; \
 	fi
 
 # Help

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-.PHONY: build build-all run test test-coverage test-race test-all clean docker-build docker-run docker-stop logs help lint fmt vet race coverage bench install-tools ci staticcheck quality security deps-graph deps docs dev pre-commit release
+SHELL := /bin/bash
+.PHONY: build build-all run test test-coverage test-race test-all clean docker-build docker-run docker-stop logs help lint fmt vet race coverage bench install-tools ci staticcheck quality security deps-graph deps docs dev pre-commit release local-ssh-keys
 
 # Variables
 
@@ -200,6 +201,20 @@ pre-commit: fmt vet lint test-race
 # Release preparation
 release: clean build-all test-all quality security
 	@echo "Release preparation complete"
+
+# Generate local TLS certs for development
+# https://letsencrypt.org/docs/certificates-for-localhost/
+local-ssh-keys:
+	@if [ -f ~/.aeroarc/local-keys/localhost.crt ] && [ -f ~/.aeroarc/local-keys/localhost.key ]; then \
+		echo "Local TLS certs already exist at ~/.aeroarc/local-keys."; \
+	else \
+		mkdir -p ~/.aeroarc/local-keys; \
+		openssl req -x509 -out ~/.aeroarc/local-keys/localhost.crt -keyout ~/.aeroarc/local-keys/localhost.key \
+			-newkey rsa:2048 -nodes -sha256 \
+			-subj '/CN=localhost' -extensions EXT -config <( \
+				printf "[dn]\nCN=localhost\n[req]\ndistinguished_name = dn\n[EXT]\nsubjectAltName=DNS:localhost\nkeyUsage=digitalSignature\nextendedKeyUsage=serverAuth"); \
+		echo "Local TLS certs generated in ~/.aeroarc/local-keys."; \
+	fi
 
 # Help
 help:


### PR DESCRIPTION
## Description
This PR adds a new make target to generate local tls certs for development environments.
## Why
The Relay and Agent in production need to communicate using TLS. To test plumbing we should probably use TLS in our local/testing environments but generating our own keys for localhost can be a time sink so adding a make target (and eventually plumbing behind `--debug`).
## Testing
```
makinje@Roxas:~/aero-arc-agent$ make local-ssh-keys 
...+...........+...+.........+.+..+.......+...........+.+..............+....+..+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
*...+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*........+....+.........+.....+......+.....................+....+...+.....+
............+.+.........+........+.....................+.+.....+.+.....+...+..........+..+.........+...+.+.....+.+...+......+..+....+.....+.....
.....+..................+...+........+.+......+........+....+...+...+..+.........+....+.....+...............+......+.+........+............+....
.....+.+.....+...+.+...+........+.......+..+.+............+........+....+...+...+...+.....................+.........+.....+....+..+.........+...
.+.................+....+......+.....+...+..........+...+...+..+.......+......+...........+.+..+.+.....+.+........++++++++++++++++++++++++++++++
+++++++++++++++++++++++++++++++++++
.......+.......+..+.+............+..+....+..+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*...+...............+.....+........
....+.+..+.............+..+...+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*..+...+...............+.......+...+..+.+++++++++
++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-----
Local TLS certs generated in ~/.aeroarc/local-keys.
makinje@Roxas:~/aero-arc-agent$ make local-ssh-keys 
```