### PR TITLE
[Agent] Enable TLS in Debug Mode

### DIFF
--- a/cmd/aero-arc-agent/main.go
+++ b/cmd/aero-arc-agent/main.go
@@ -14,7 +14,6 @@ import (
 )
 
 var agentCmd = cli.Command{
-	Name:   "run",
 	Usage:  "run the agent edge process",
 	Action: RunAgent,
 

--- a/cmd/aero-arc-agent/main.go
+++ b/cmd/aero-arc-agent/main.go
@@ -92,10 +92,10 @@ func RunAgent(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("failed to construct agent: %v", err)
 	}
 
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	sigCtx, cancel := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer cancel()
 
-	return a.Start(ctx, sigCh)
+	return a.Start(sigCtx)
 }
 
 func main() {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -281,13 +281,14 @@ func (a *Agent) establishRelayConnection(ctx context.Context) (*grpc.ClientConn,
 	var creds credentials.TransportCredentials
 	var err error
 
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		slog.LogAttrs(ctx, slog.LevelError, ErrGettingHomeDir.Error(), slog.String("error", err.Error()))
-		return nil, ErrGettingHomeDir
-	}
-
 	if a.options.Debug {
+
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			slog.LogAttrs(ctx, slog.LevelError, ErrGettingHomeDir.Error(), slog.String("error", err.Error()))
+			return nil, ErrGettingHomeDir
+		}
+
 		certPath := fmt.Sprintf("%s/%s", homeDir, DebugTLSCertPath)
 		creds, err = credentials.NewClientTLSFromFile(certPath, "localhost")
 		if err != nil {

--- a/internal/agent/constants.go
+++ b/internal/agent/constants.go
@@ -1,0 +1,6 @@
+package agent
+
+const (
+	DebugTLSCertPath = ".aeroarc/local-certs/localhost.crt"
+	DebugTLSKeyPath  = ".aeroarc/local-certs/localhost.key"
+)

--- a/internal/agent/errors.go
+++ b/internal/agent/errors.go
@@ -17,4 +17,6 @@ var (
 
 	ErrGatewayNotInitialized = errors.New("agent gateway client not initialized")
 	ErrFailedToMarkDelivered = errors.New("failed to mark wal entry as delivered")
+
+	ErrGettingHomeDir = errors.New("error getting user home directory")
 )

--- a/internal/wal/wal_test.go
+++ b/internal/wal/wal_test.go
@@ -16,7 +16,7 @@ func TestWAL_Lifecycle(t *testing.T) {
 	tmpDir := t.TempDir()
 	dbPath := filepath.Join(tmpDir, "wal_lifecycle.db")
 
-	w, err := New(dbPath, 0, 0)
+	w, err := New(context.Background(), dbPath, 0, 0)
 	if err != nil {
 		t.Fatalf("Failed to create WAL: %v", err)
 	}
@@ -73,7 +73,7 @@ func TestWAL_AsyncBatching(t *testing.T) {
 	tmpDir := t.TempDir()
 	dbPath := filepath.Join(tmpDir, "test_async.db")
 	// Use small batch size and short timeout for testing
-	w, err := New(dbPath, 2, 50*time.Millisecond)
+	w, err := New(context.Background(), dbPath, 2, 50*time.Millisecond)
 	if err != nil {
 		t.Fatalf("Failed to open WAL: %v", err)
 	}
@@ -145,7 +145,7 @@ func TestWAL_AsyncBatching(t *testing.T) {
 func TestWAL_SpoolAndDrain(t *testing.T) {
 	tmpDir := t.TempDir()
 	dbPath := filepath.Join(tmpDir, "test_spool.db")
-	w, err := New(dbPath, 2, time.Hour)
+	w, err := New(context.Background(), dbPath, 2, time.Hour)
 	if err != nil {
 		t.Fatalf("Failed to open WAL: %v", err)
 	}
@@ -303,7 +303,7 @@ func TestWAL_ReadLimit(t *testing.T) {
 func mustNewWAL(t *testing.T) *WAL {
 	tmpDir := t.TempDir()
 	dbPath := filepath.Join(tmpDir, "test.db")
-	w, err := New(dbPath, 0, 0)
+	w, err := New(context.Background(), dbPath, 0, 0)
 	if err != nil {
 		t.Fatalf("Failed to open WAL: %v", err)
 	}


### PR DESCRIPTION
## Description
This PR enables TLS for the communication between the agent and relay services in debug mode.
## Why
Dev and Prod should have parity. With the inclusion of #40 we can generate locally signed certs so using them in debug mode makes total sense.
## Testing
- [x] Ran Agent -> Relay and verified data transmission