### PR TITLE
Track flight operation context on agents

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.9
 
 require (
-	github.com/aero-arc/aero-arc-protos v0.0.0-20260712235411-7691110ca7e7
+	github.com/aero-arc/aero-arc-protos v0.0.0-20260713020927-fc6acd6bed87
 	google.golang.org/grpc v1.77.0
 	modernc.org/sqlite v1.40.1
 )

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.9
 
 require (
-	github.com/aero-arc/aero-arc-protos v0.0.0-20260102021844-71907cb05f5f
+	github.com/aero-arc/aero-arc-protos v0.0.0-20260712235411-7691110ca7e7
 	google.golang.org/grpc v1.77.0
 	modernc.org/sqlite v1.40.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 bou.ke/monkey v1.0.2 h1:kWcnsrCNUatbxncxR/ThdYqbytgOIArtYWqcQLQzKLI=
 bou.ke/monkey v1.0.2/go.mod h1:OqickVX3tNx6t33n1xvtTtu85YN5s6cKwVug+oHMaIA=
-github.com/aero-arc/aero-arc-protos v0.0.0-20260102021844-71907cb05f5f h1:llOCBIopyYrbJUjk33I7nVSpeTkueabhHZEGa9Uesjg=
-github.com/aero-arc/aero-arc-protos v0.0.0-20260102021844-71907cb05f5f/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260712235411-7691110ca7e7 h1:Ex8lT3tkVP902PfjJiRU2E4Q4L4H7eyfzgwSUu+WiGw=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260712235411-7691110ca7e7/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
 github.com/bluenviron/gomavlib/v3 v3.3.0 h1:ul1yiDslfvsqCjLs+by1eSdU8Oud5qwemoO5ZBpX/fs=
 github.com/bluenviron/gomavlib/v3 v3.3.0/go.mod h1:pPrXt2HspzeIKNlvSDCrPzwPSLPDXORfhWJ8vT8zEKk=
 github.com/creack/goselect v0.1.2 h1:2DNy14+JPjRBgPzAd1thbQp4BSIihxcBf0IXhQXDRa0=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 bou.ke/monkey v1.0.2 h1:kWcnsrCNUatbxncxR/ThdYqbytgOIArtYWqcQLQzKLI=
 bou.ke/monkey v1.0.2/go.mod h1:OqickVX3tNx6t33n1xvtTtu85YN5s6cKwVug+oHMaIA=
-github.com/aero-arc/aero-arc-protos v0.0.0-20260712235411-7691110ca7e7 h1:Ex8lT3tkVP902PfjJiRU2E4Q4L4H7eyfzgwSUu+WiGw=
-github.com/aero-arc/aero-arc-protos v0.0.0-20260712235411-7691110ca7e7/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260713020927-fc6acd6bed87 h1:GfcrJwpuqOrVE1qVFnlB1L/kd2qY0r/lBgwRd8XuFpw=
+github.com/aero-arc/aero-arc-protos v0.0.0-20260713020927-fc6acd6bed87/go.mod h1:fILW3Dz6auXllS5ABRFTt0FTnNC4Mtw3ukvGrJa7zLo=
 github.com/bluenviron/gomavlib/v3 v3.3.0 h1:ul1yiDslfvsqCjLs+by1eSdU8Oud5qwemoO5ZBpX/fs=
 github.com/bluenviron/gomavlib/v3 v3.3.0/go.mod h1:pPrXt2HspzeIKNlvSDCrPzwPSLPDXORfhWJ8vT8zEKk=
 github.com/creack/goselect v0.1.2 h1:2DNy14+JPjRBgPzAd1thbQp4BSIihxcBf0IXhQXDRa0=

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -339,12 +339,17 @@ func (a *Agent) processFrame(ctx context.Context, frame *gomavlib.EventFrame) er
 func (a *Agent) stampFrameContext(frame *agentv1.TelemetryFrame) {
 	a.stateMu.RLock()
 	defer a.stateMu.RUnlock()
-	frame.SessionId = a.sessionID
 	if active := a.operationContext; active != nil {
 		frame.FlightId = active.FlightID
 		frame.IntentId = active.IntentID
 		frame.IntentVersion = active.IntentVersion
 	}
+}
+
+func (a *Agent) stampCurrentSession(frame *agentv1.TelemetryFrame) {
+	a.stateMu.RLock()
+	defer a.stateMu.RUnlock()
+	frame.SessionId = a.sessionID
 }
 
 // dialRelay establishes a gRPC connection to the relay using the configured target.
@@ -617,6 +622,7 @@ func (a *Agent) handleTelemetryFrames(ctx context.Context, stream grpc.BidiStrea
 				continue
 			}
 			tFrame.Seq = uint64(entries[i].ID)
+			a.stampCurrentSession(tFrame)
 
 			message := &agentv1.AgentStreamMessage{Payload: &agentv1.AgentStreamMessage_TelemetryFrame{TelemetryFrame: tFrame}}
 			a.sendMu.Lock()

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -538,6 +538,9 @@ func (a *Agent) handleClearOperationContext(ctx context.Context, stream grpc.Bid
 	if command.GetCommandId() == "" {
 		return a.sendOperationContextAck(stream, "", agentv1.OperationContextCommandAck_STATUS_REJECTED, "command_id is required")
 	}
+	if command.GetFlightId() == "" {
+		return a.sendOperationContextAck(stream, command.GetCommandId(), agentv1.OperationContextCommandAck_STATUS_REJECTED, "flight id is required")
+	}
 	applied, err := a.wal.ClearOperationContext(ctx, command.CommandId, command.FlightId)
 	if err != nil {
 		return a.sendOperationContextAck(stream, command.CommandId, agentv1.OperationContextCommandAck_STATUS_TEMPORARY_ERROR, err.Error())

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -42,9 +43,14 @@ type Agent struct {
 	// the concrete implementations below.
 	dialFn        func(ctx context.Context) (*grpc.ClientConn, error)
 	registerFn    func(ctx context.Context) error
-	openStreamFn  func(ctx context.Context) (grpc.BidiStreamingClient[agentv1.TelemetryFrame, agentv1.TelemetryAck], error)
-	ackLoopFn     func(ctx context.Context, stream grpc.BidiStreamingClient[agentv1.TelemetryFrame, agentv1.TelemetryAck]) error
+	openStreamFn  func(ctx context.Context) (grpc.BidiStreamingClient[agentv1.AgentStreamMessage, agentv1.RelayStreamMessage], error)
+	ackLoopFn     func(ctx context.Context, stream grpc.BidiStreamingClient[agentv1.AgentStreamMessage, agentv1.RelayStreamMessage]) error
 	sleepWithBack func(ctx context.Context, d time.Duration) bool
+
+	stateMu          sync.RWMutex
+	sessionID        string
+	operationContext *wal.OperationContext
+	sendMu           sync.Mutex
 
 	ingestCount atomic.Uint64
 	sendCount   atomic.Uint64
@@ -122,6 +128,11 @@ func (a *Agent) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to initialize WAL: %w", err)
 	}
 	a.wal = w
+	if operationContext, ok, err := w.LoadOperationContext(ctx); err != nil {
+		return err
+	} else if ok {
+		a.operationContext = &operationContext
+	}
 	slog.LogAttrs(ctx, slog.LevelInfo, "wal_initialized", slog.String("path", a.options.WALPath))
 
 	a.wg.Add(1)
@@ -314,6 +325,7 @@ func (a *Agent) processFrame(ctx context.Context, frame *gomavlib.EventFrame) er
 		Fields:       fields,
 		AgentId:      identity.Resolve().FinalID,
 	}
+	a.stampFrameContext(tFrame)
 
 	// Write to WAL asynchronously
 	if err := a.wal.AppendAsync(ctx, tFrame); err != nil {
@@ -322,6 +334,17 @@ func (a *Agent) processFrame(ctx context.Context, frame *gomavlib.EventFrame) er
 	a.ingestCount.Add(1)
 
 	return nil
+}
+
+func (a *Agent) stampFrameContext(frame *agentv1.TelemetryFrame) {
+	a.stateMu.RLock()
+	defer a.stateMu.RUnlock()
+	frame.SessionId = a.sessionID
+	if active := a.operationContext; active != nil {
+		frame.FlightId = active.FlightID
+		frame.IntentId = active.IntentID
+		frame.IntentVersion = active.IntentVersion
+	}
 }
 
 // dialRelay establishes a gRPC connection to the relay using the configured target.
@@ -391,10 +414,16 @@ func (a *Agent) register(ctx context.Context) error {
 	)
 
 	regCtx := metadata.AppendToOutgoingContext(ctx, "aero-arc-agent-id", agentID)
-	_, err := a.gateway.Register(regCtx, req)
+	response, err := a.gateway.Register(regCtx, req)
 	if err != nil {
 		return err
 	}
+	if response.GetSessionId() == "" {
+		return errors.New("relay registration returned an empty session ID")
+	}
+	a.stateMu.Lock()
+	a.sessionID = response.GetSessionId()
+	a.stateMu.Unlock()
 
 	slog.LogAttrs(
 		ctx, slog.LevelInfo,
@@ -406,7 +435,7 @@ func (a *Agent) register(ctx context.Context) error {
 }
 
 // openTelemetryStream opens the bidi telemetry stream.
-func (a *Agent) openTelemetryStream(ctx context.Context) (grpc.BidiStreamingClient[agentv1.TelemetryFrame, agentv1.TelemetryAck], error) {
+func (a *Agent) openTelemetryStream(ctx context.Context) (grpc.BidiStreamingClient[agentv1.AgentStreamMessage, agentv1.RelayStreamMessage], error) {
 	if a.gateway == nil {
 		return nil, ErrGatewayNotInitialized
 	}
@@ -436,24 +465,107 @@ func (a *Agent) openTelemetryStream(ctx context.Context) (grpc.BidiStreamingClie
 
 // runStreamLoop handles the receive side of the telemetry stream. Outbound
 // sends will be wired in a later iteration once the queue is implemented.
-func (a *Agent) runAckLoop(ctx context.Context, stream grpc.BidiStreamingClient[agentv1.TelemetryFrame, agentv1.TelemetryAck]) error {
+func (a *Agent) runAckLoop(ctx context.Context, stream grpc.BidiStreamingClient[agentv1.AgentStreamMessage, agentv1.RelayStreamMessage]) error {
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
-			ack, err := stream.Recv()
+			message, err := stream.Recv()
 			if err != nil {
 				return err
 			}
 
-			err = a.handleTelemetryAck(ctx, ack)
+			err = a.handleRelayMessage(ctx, stream, message)
 			if err != nil {
 				// TODO: Handle error? Should we retry? Definitely shouldn't just exit.
 				return err
 			}
 		}
 	}
+}
+
+func (a *Agent) handleRelayMessage(ctx context.Context, stream grpc.BidiStreamingClient[agentv1.AgentStreamMessage, agentv1.RelayStreamMessage], message *agentv1.RelayStreamMessage) error {
+	switch payload := message.GetPayload().(type) {
+	case *agentv1.RelayStreamMessage_TelemetryAck:
+		return a.handleTelemetryAck(ctx, payload.TelemetryAck)
+	case *agentv1.RelayStreamMessage_SetOperationContext:
+		return a.handleSetOperationContext(ctx, stream, payload.SetOperationContext)
+	case *agentv1.RelayStreamMessage_ClearOperationContext:
+		return a.handleClearOperationContext(ctx, stream, payload.ClearOperationContext)
+	default:
+		return errors.New("relay stream message has no supported payload")
+	}
+}
+
+func (a *Agent) handleSetOperationContext(ctx context.Context, stream grpc.BidiStreamingClient[agentv1.AgentStreamMessage, agentv1.RelayStreamMessage], command *agentv1.SetOperationContextCommand) error {
+	if command.GetCommandId() == "" || command.GetContext() == nil || command.GetContext().GetFlightId() == "" {
+		return a.sendOperationContextAck(stream, command.GetCommandId(), agentv1.OperationContextCommandAck_STATUS_REJECTED, "command_id and flight_id are required")
+	}
+	value := wal.OperationContext{FlightID: command.Context.FlightId, IntentID: command.Context.IntentId, IntentVersion: command.Context.IntentVersion}
+	applied, err := a.wal.SetOperationContext(ctx, command.CommandId, value)
+	if err != nil {
+		return a.sendOperationContextAck(stream, command.CommandId, agentv1.OperationContextCommandAck_STATUS_TEMPORARY_ERROR, err.Error())
+	}
+	status := agentv1.OperationContextCommandAck_STATUS_APPLIED
+	if !applied {
+		status = agentv1.OperationContextCommandAck_STATUS_ALREADY_APPLIED
+		persisted, ok, loadErr := a.wal.LoadOperationContext(ctx)
+		if loadErr != nil {
+			return loadErr
+		}
+		a.stateMu.Lock()
+		if ok {
+			a.operationContext = &persisted
+		} else {
+			a.operationContext = nil
+		}
+		a.stateMu.Unlock()
+		return a.sendOperationContextAck(stream, command.CommandId, status, "")
+	}
+	a.stateMu.Lock()
+	a.operationContext = &value
+	a.stateMu.Unlock()
+	return a.sendOperationContextAck(stream, command.CommandId, status, "")
+}
+
+func (a *Agent) handleClearOperationContext(ctx context.Context, stream grpc.BidiStreamingClient[agentv1.AgentStreamMessage, agentv1.RelayStreamMessage], command *agentv1.ClearOperationContextCommand) error {
+	if command.GetCommandId() == "" {
+		return a.sendOperationContextAck(stream, "", agentv1.OperationContextCommandAck_STATUS_REJECTED, "command_id is required")
+	}
+	applied, err := a.wal.ClearOperationContext(ctx, command.CommandId, command.FlightId)
+	if err != nil {
+		return a.sendOperationContextAck(stream, command.CommandId, agentv1.OperationContextCommandAck_STATUS_TEMPORARY_ERROR, err.Error())
+	}
+	active, ok, err := a.wal.LoadOperationContext(ctx)
+	if err != nil {
+		return err
+	}
+	a.stateMu.Lock()
+	if ok {
+		a.operationContext = &active
+	} else {
+		a.operationContext = nil
+	}
+	a.stateMu.Unlock()
+	status := agentv1.OperationContextCommandAck_STATUS_APPLIED
+	if !applied {
+		status = agentv1.OperationContextCommandAck_STATUS_ALREADY_APPLIED
+	}
+	return a.sendOperationContextAck(stream, command.CommandId, status, "")
+}
+
+func (a *Agent) sendOperationContextAck(stream grpc.BidiStreamingClient[agentv1.AgentStreamMessage, agentv1.RelayStreamMessage], commandID string, status agentv1.OperationContextCommandAck_Status, errorMessage string) error {
+	a.stateMu.RLock()
+	var active *agentv1.OperationContext
+	if value := a.operationContext; value != nil {
+		active = &agentv1.OperationContext{FlightId: value.FlightID, IntentId: value.IntentID, IntentVersion: value.IntentVersion}
+	}
+	a.stateMu.RUnlock()
+	message := &agentv1.AgentStreamMessage{Payload: &agentv1.AgentStreamMessage_OperationContextCommandAck{OperationContextCommandAck: &agentv1.OperationContextCommandAck{CommandId: commandID, Status: status, Error: errorMessage, ActiveContext: active}}}
+	a.sendMu.Lock()
+	defer a.sendMu.Unlock()
+	return stream.Send(message)
 }
 
 func (a *Agent) handleTelemetryAck(ctx context.Context, ack *agentv1.TelemetryAck) error {
@@ -470,7 +582,7 @@ func (a *Agent) handleTelemetryAck(ctx context.Context, ack *agentv1.TelemetryAc
 	return nil
 }
 
-func (a *Agent) handleTelemetryFrames(ctx context.Context, stream grpc.BidiStreamingClient[agentv1.TelemetryFrame, agentv1.TelemetryAck]) error {
+func (a *Agent) handleTelemetryFrames(ctx context.Context, stream grpc.BidiStreamingClient[agentv1.AgentStreamMessage, agentv1.RelayStreamMessage]) error {
 	// The new architecture unifies "Replay" and "Live" into a single loop.
 	// 1. We poll the WAL for undelivered frames.
 	// 2. We send them.
@@ -506,7 +618,11 @@ func (a *Agent) handleTelemetryFrames(ctx context.Context, stream grpc.BidiStrea
 			}
 			tFrame.Seq = uint64(entries[i].ID)
 
-			if err := stream.Send(tFrame); err != nil {
+			message := &agentv1.AgentStreamMessage{Payload: &agentv1.AgentStreamMessage_TelemetryFrame{TelemetryFrame: tFrame}}
+			a.sendMu.Lock()
+			err := stream.Send(message)
+			a.sendMu.Unlock()
+			if err != nil {
 				slog.LogAttrs(ctx, slog.LevelError, "telemetry_frame_send_error", slog.String("error", err.Error()))
 				break
 			}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -499,7 +499,7 @@ func (a *Agent) handleRelayMessage(ctx context.Context, stream grpc.BidiStreamin
 	case *agentv1.RelayStreamMessage_ClearOperationContext:
 		return a.handleClearOperationContext(ctx, stream, payload.ClearOperationContext)
 	default:
-		return errors.New("relay stream message has no supported payload")
+		return a.sendOperationContextAck(stream, "", agentv1.OperationContextCommandAck_STATUS_REJECTED, "relay stream message has no supported payload")
 	}
 }
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -464,6 +464,27 @@ func TestHandleRelayMessageDispatchesTelemetryAck(t *testing.T) {
 	}
 }
 
+func TestHandleRelayMessageRejectsUnsupportedPayload(t *testing.T) {
+	var sent *agentv1.AgentStreamMessage
+	stream := &mockStream{sendFunc: func(message *agentv1.AgentStreamMessage) error {
+		sent = message
+		return nil
+	}}
+
+	a := &Agent{}
+	if err := a.handleRelayMessage(context.Background(), stream, &agentv1.RelayStreamMessage{}); err != nil {
+		t.Fatal(err)
+	}
+
+	ack := sent.GetOperationContextCommandAck()
+	if ack.GetStatus() != agentv1.OperationContextCommandAck_STATUS_REJECTED {
+		t.Fatalf("unsupported payload status = %v, want %v", ack.GetStatus(), agentv1.OperationContextCommandAck_STATUS_REJECTED)
+	}
+	if ack.GetCommandId() != "" || ack.GetError() == "" {
+		t.Fatalf("unsupported payload ack = %+v", ack)
+	}
+}
+
 func TestNewAgent(t *testing.T) {
 	opts := &AgentOptions{
 		RelayTarget: "localhost:9090",

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestNextBackoff(t *testing.T) {
@@ -53,11 +54,11 @@ func TestRunWithReconnect_DialFailureHonorsContextAndBackoff(t *testing.T) {
 		t.Fatalf("register should not be called on dial failure")
 		return nil
 	}
-	a.openStreamFn = func(ctx context.Context) (grpc.BidiStreamingClient[agentv1.TelemetryFrame, agentv1.TelemetryAck], error) {
+	a.openStreamFn = func(ctx context.Context) (grpc.BidiStreamingClient[agentv1.AgentStreamMessage, agentv1.RelayStreamMessage], error) {
 		t.Fatalf("openStreamFn should not be called on dial failure")
 		return nil, nil
 	}
-	a.ackLoopFn = func(ctx context.Context, stream grpc.BidiStreamingClient[agentv1.TelemetryFrame, agentv1.TelemetryAck]) error {
+	a.ackLoopFn = func(ctx context.Context, stream grpc.BidiStreamingClient[agentv1.AgentStreamMessage, agentv1.RelayStreamMessage]) error {
 		t.Fatalf("ackLoopFn should not be called on dial failure")
 		return nil
 	}
@@ -83,18 +84,18 @@ func TestRunWithReconnect_DialFailureHonorsContextAndBackoff(t *testing.T) {
 // Mock Stream Implementation
 type mockStream struct {
 	grpc.ClientStream
-	recvFunc func() (*agentv1.TelemetryAck, error)
-	sendFunc func(*agentv1.TelemetryFrame) error
+	recvFunc func() (*agentv1.RelayStreamMessage, error)
+	sendFunc func(*agentv1.AgentStreamMessage) error
 }
 
-func (m *mockStream) Recv() (*agentv1.TelemetryAck, error) {
+func (m *mockStream) Recv() (*agentv1.RelayStreamMessage, error) {
 	if m.recvFunc != nil {
 		return m.recvFunc()
 	}
 	return nil, io.EOF
 }
 
-func (m *mockStream) Send(f *agentv1.TelemetryFrame) error {
+func (m *mockStream) Send(f *agentv1.AgentStreamMessage) error {
 	if m.sendFunc != nil {
 		return m.sendFunc(f)
 	}
@@ -162,10 +163,10 @@ func TestRunWithReconnect_StreamFailureTriggersReconnect(t *testing.T) {
 		return nil
 	}
 
-	a.openStreamFn = func(ctx context.Context) (grpc.BidiStreamingClient[agentv1.TelemetryFrame, agentv1.TelemetryAck], error) {
+	a.openStreamFn = func(ctx context.Context) (grpc.BidiStreamingClient[agentv1.AgentStreamMessage, agentv1.RelayStreamMessage], error) {
 		streamOpenCount++
 		return &mockStream{
-			recvFunc: func() (*agentv1.TelemetryAck, error) {
+			recvFunc: func() (*agentv1.RelayStreamMessage, error) {
 				// Block slightly then return error to simulate disconnect
 				select {
 				case <-ctx.Done():
@@ -177,7 +178,7 @@ func TestRunWithReconnect_StreamFailureTriggersReconnect(t *testing.T) {
 		}, nil
 	}
 
-	a.ackLoopFn = func(ctx context.Context, stream grpc.BidiStreamingClient[agentv1.TelemetryFrame, agentv1.TelemetryAck]) error {
+	a.ackLoopFn = func(ctx context.Context, stream grpc.BidiStreamingClient[agentv1.AgentStreamMessage, agentv1.RelayStreamMessage]) error {
 		// Just call Recv until error
 		for {
 			_, err := stream.Recv()
@@ -281,7 +282,7 @@ func TestRegister(t *testing.T) {
 			if in.AgentId == "" {
 				return nil, errors.New("empty agent id")
 			}
-			return &agentv1.RegisterResponse{}, nil
+			return &agentv1.RegisterResponse{SessionId: "session-1"}, nil
 		},
 	}
 
@@ -293,11 +294,123 @@ func TestRegister(t *testing.T) {
 	if err := a.register(ctx); err != nil {
 		t.Fatalf("register failed: %v", err)
 	}
+	if a.sessionID != "session-1" {
+		t.Fatalf("sessionID = %q, want session-1", a.sessionID)
+	}
 
 	// Test failure case
 	a.gateway = nil
 	if err := a.register(ctx); err != ErrGatewayNotInitialized {
 		t.Errorf("expected ErrGatewayNotInitialized, got %v", err)
+	}
+}
+
+func TestOperationContextLifecycleAndFrameSnapshot(t *testing.T) {
+	ctx := context.Background()
+	w, err := wal.New(ctx, filepath.Join(t.TempDir(), "wal.db"), 10, time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+
+	var sent []*agentv1.AgentStreamMessage
+	stream := &mockStream{sendFunc: func(message *agentv1.AgentStreamMessage) error {
+		sent = append(sent, message)
+		return nil
+	}}
+	a := &Agent{wal: w, sessionID: "session-1"}
+	set := &agentv1.SetOperationContextCommand{
+		CommandId: "set-1",
+		Context:   &agentv1.OperationContext{FlightId: "flight-1", IntentId: "intent-1", IntentVersion: 2},
+	}
+	if err := a.handleSetOperationContext(ctx, stream, set); err != nil {
+		t.Fatal(err)
+	}
+	if got := sent[len(sent)-1].GetOperationContextCommandAck().GetStatus(); got != agentv1.OperationContextCommandAck_STATUS_APPLIED {
+		t.Fatalf("set status = %v", got)
+	}
+
+	frame := &agentv1.TelemetryFrame{}
+	a.stampFrameContext(frame)
+	if frame.SessionId != "session-1" || frame.FlightId != "flight-1" || frame.IntentId != "intent-1" || frame.IntentVersion != 2 {
+		t.Fatalf("stamped frame = %+v", frame)
+	}
+	walID, err := w.Append(ctx, frame)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The same durable command is acknowledged without replacing its original value.
+	set.Context.FlightId = "incorrect-retry-value"
+	if err := a.handleSetOperationContext(ctx, stream, set); err != nil {
+		t.Fatal(err)
+	}
+	ack := sent[len(sent)-1].GetOperationContextCommandAck()
+	if ack.GetStatus() != agentv1.OperationContextCommandAck_STATUS_ALREADY_APPLIED || ack.GetActiveContext().GetFlightId() != "flight-1" {
+		t.Fatalf("duplicate ack = %+v", ack)
+	}
+
+	// A stale clear is recorded but cannot clear a newer/different flight.
+	if err := a.handleClearOperationContext(ctx, stream, &agentv1.ClearOperationContextCommand{CommandId: "clear-old", FlightId: "flight-old"}); err != nil {
+		t.Fatal(err)
+	}
+	frame = &agentv1.TelemetryFrame{}
+	a.stampFrameContext(frame)
+	if frame.FlightId != "flight-1" {
+		t.Fatalf("stale clear changed flight to %q", frame.FlightId)
+	}
+
+	if err := a.handleClearOperationContext(ctx, stream, &agentv1.ClearOperationContextCommand{CommandId: "clear-1", FlightId: "flight-1"}); err != nil {
+		t.Fatal(err)
+	}
+	frame = &agentv1.TelemetryFrame{}
+	a.stampFrameContext(frame)
+	if frame.FlightId != "" || frame.IntentId != "" {
+		t.Fatalf("frame retained cleared context: %+v", frame)
+	}
+	if err := a.handleSetOperationContext(ctx, stream, set); err != nil {
+		t.Fatal(err)
+	}
+	frame = &agentv1.TelemetryFrame{}
+	a.stampFrameContext(frame)
+	if frame.FlightId != "" {
+		t.Fatalf("retry of old set resurrected cleared context: %+v", frame)
+	}
+	entries, err := w.ReadUndelivered(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stored agentv1.TelemetryFrame
+	for _, entry := range entries {
+		if entry.ID == walID {
+			if err := proto.Unmarshal(entry.Payload, &stored); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	if stored.FlightId != "flight-1" || stored.IntentId != "intent-1" || stored.IntentVersion != 2 {
+		t.Fatalf("WAL frame context changed after clear: %+v", stored)
+	}
+}
+
+func TestHandleRelayMessageDispatchesTelemetryAck(t *testing.T) {
+	ctx := context.Background()
+	w, err := wal.New(ctx, filepath.Join(t.TempDir(), "wal.db"), 10, time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+	id, err := w.Append(ctx, &agentv1.TelemetryFrame{AgentId: "agent-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := &Agent{wal: w}
+	message := &agentv1.RelayStreamMessage{Payload: &agentv1.RelayStreamMessage_TelemetryAck{TelemetryAck: &agentv1.TelemetryAck{Seq: uint64(id)}}}
+	if err := a.handleRelayMessage(ctx, &mockStream{}, message); err != nil {
+		t.Fatal(err)
+	}
+	if entries, err := w.ReadUndelivered(ctx, 10); err != nil || len(entries) != 0 {
+		t.Fatalf("undelivered after ack = %d, %v", len(entries), err)
 	}
 }
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -332,7 +332,7 @@ func TestOperationContextLifecycleAndFrameSnapshot(t *testing.T) {
 
 	frame := &agentv1.TelemetryFrame{}
 	a.stampFrameContext(frame)
-	if frame.SessionId != "session-1" || frame.FlightId != "flight-1" || frame.IntentId != "intent-1" || frame.IntentVersion != 2 {
+	if frame.SessionId != "" || frame.FlightId != "flight-1" || frame.IntentId != "intent-1" || frame.IntentVersion != 2 {
 		t.Fatalf("stamped frame = %+v", frame)
 	}
 	walID, err := w.Append(ctx, frame)
@@ -390,6 +390,42 @@ func TestOperationContextLifecycleAndFrameSnapshot(t *testing.T) {
 	}
 	if stored.FlightId != "flight-1" || stored.IntentId != "intent-1" || stored.IntentVersion != 2 {
 		t.Fatalf("WAL frame context changed after clear: %+v", stored)
+	}
+}
+
+func TestSessionIsStampedAtSendTimeAcrossOfflineCaptureAndReconnect(t *testing.T) {
+	a := &Agent{}
+
+	// A frame captured offline has no session, because sessions describe relay
+	// connections rather than the capture event.
+	offline := &agentv1.TelemetryFrame{}
+	a.stampFrameContext(offline)
+	if offline.SessionId != "" {
+		t.Fatalf("offline frame session = %q", offline.SessionId)
+	}
+
+	// The first successful registration supplies the session used when replaying.
+	a.gateway = &mockGateway{registerFunc: func(context.Context, *agentv1.RegisterRequest, ...grpc.CallOption) (*agentv1.RegisterResponse, error) {
+		return &agentv1.RegisterResponse{SessionId: "session-1"}, nil
+	}}
+	a.options = &AgentOptions{RelayTarget: "relay"}
+	if err := a.register(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	a.stampCurrentSession(offline)
+	if offline.SessionId != "session-1" {
+		t.Fatalf("first replay session = %q", offline.SessionId)
+	}
+
+	// A WAL frame containing a prior connection's session is overwritten after
+	// reconnect rather than rejected as stale by the relay.
+	oldWALFrame := &agentv1.TelemetryFrame{SessionId: "session-old"}
+	a.stateMu.Lock()
+	a.sessionID = "session-2"
+	a.stateMu.Unlock()
+	a.stampCurrentSession(oldWALFrame)
+	if oldWALFrame.SessionId != "session-2" {
+		t.Fatalf("reconnected replay session = %q", oldWALFrame.SessionId)
 	}
 }
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -350,6 +350,20 @@ func TestOperationContextLifecycleAndFrameSnapshot(t *testing.T) {
 		t.Fatalf("duplicate ack = %+v", ack)
 	}
 
+	// A malformed clear is rejected, correlated to its command, and leaves the active context intact.
+	if err := a.handleClearOperationContext(ctx, stream, &agentv1.ClearOperationContextCommand{CommandId: "clear-empty"}); err != nil {
+		t.Fatal(err)
+	}
+	ack = sent[len(sent)-1].GetOperationContextCommandAck()
+	if ack.GetCommandId() != "clear-empty" || ack.GetStatus() != agentv1.OperationContextCommandAck_STATUS_REJECTED {
+		t.Fatalf("empty-flight clear ack = %+v", ack)
+	}
+	frame = &agentv1.TelemetryFrame{}
+	a.stampFrameContext(frame)
+	if frame.FlightId != "flight-1" {
+		t.Fatalf("empty-flight clear changed flight to %q", frame.FlightId)
+	}
+
 	// A stale clear is recorded but cannot clear a newer/different flight.
 	if err := a.handleClearOperationContext(ctx, stream, &agentv1.ClearOperationContextCommand{CommandId: "clear-old", FlightId: "flight-old"}); err != nil {
 		t.Fatal(err)

--- a/internal/wal/wal.go
+++ b/internal/wal/wal.go
@@ -184,14 +184,15 @@ func (w *WAL) SetOperationContext(ctx context.Context, commandID string, value O
 
 // ClearOperationContext atomically clears the active context once.
 func (w *WAL) ClearOperationContext(ctx context.Context, commandID, flightID string) (bool, error) {
+	if commandID == "" {
+		return false, errors.New("operation command ID is required")
+	}
+	if flightID == "" {
+		return false, errors.New("flight ID is required")
+	}
+
 	return w.applyOperationCommand(ctx, commandID, func(tx *sql.Tx) error {
-		query := `DELETE FROM operation_context WHERE id = 1`
-		args := []any{}
-		if flightID != "" {
-			query += ` AND flight_id = ?`
-			args = append(args, flightID)
-		}
-		_, err := tx.ExecContext(ctx, query, args...)
+		_, err := tx.ExecContext(ctx, `DELETE FROM operation_context WHERE id = 1 AND flight_id = ?`, flightID)
 		return err
 	})
 }

--- a/internal/wal/wal.go
+++ b/internal/wal/wal.go
@@ -115,6 +115,17 @@ func initDB(db *sql.DB) error {
 		payload BLOB NOT NULL,
 		delivery_status INTEGER NOT NULL DEFAULT 0
 	);
+	CREATE TABLE IF NOT EXISTS operation_context (
+		id INTEGER PRIMARY KEY CHECK (id = 1),
+		flight_id TEXT NOT NULL,
+		intent_id TEXT NOT NULL,
+		intent_version INTEGER NOT NULL,
+		updated_at INTEGER NOT NULL
+	);
+	CREATE TABLE IF NOT EXISTS operation_context_commands (
+		command_id TEXT PRIMARY KEY,
+		processed_at INTEGER NOT NULL
+	);
 	`
 	_, err := db.Exec(query)
 	if err != nil {
@@ -131,6 +142,88 @@ func initDB(db *sql.DB) error {
 	}
 
 	return nil
+}
+
+// OperationContext is the capture-time flight attribution persisted by the agent.
+type OperationContext struct {
+	FlightID      string
+	IntentID      string
+	IntentVersion uint32
+}
+
+// LoadOperationContext returns the currently active context, if one exists.
+func (w *WAL) LoadOperationContext(ctx context.Context) (OperationContext, bool, error) {
+	var value OperationContext
+	var version int64
+	err := w.db.QueryRowContext(ctx, `SELECT flight_id, intent_id, intent_version FROM operation_context WHERE id = 1`).
+		Scan(&value.FlightID, &value.IntentID, &version)
+	if errors.Is(err, sql.ErrNoRows) {
+		return OperationContext{}, false, nil
+	}
+	if err != nil {
+		return OperationContext{}, false, fmt.Errorf("load operation context: %w", err)
+	}
+	if version < 0 || version > int64(^uint32(0)) {
+		return OperationContext{}, false, fmt.Errorf("load operation context: invalid intent version %d", version)
+	}
+	value.IntentVersion = uint32(version)
+	return value, true, nil
+}
+
+// SetOperationContext atomically applies a command once. Repeated command IDs
+// are successful no-ops so command acknowledgements can safely be retried.
+func (w *WAL) SetOperationContext(ctx context.Context, commandID string, value OperationContext) (bool, error) {
+	return w.applyOperationCommand(ctx, commandID, func(tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `INSERT INTO operation_context(id, flight_id, intent_id, intent_version, updated_at)
+			VALUES(1, ?, ?, ?, ?) ON CONFLICT(id) DO UPDATE SET flight_id=excluded.flight_id,
+			intent_id=excluded.intent_id, intent_version=excluded.intent_version, updated_at=excluded.updated_at`,
+			value.FlightID, value.IntentID, value.IntentVersion, time.Now().UnixNano())
+		return err
+	})
+}
+
+// ClearOperationContext atomically clears the active context once.
+func (w *WAL) ClearOperationContext(ctx context.Context, commandID, flightID string) (bool, error) {
+	return w.applyOperationCommand(ctx, commandID, func(tx *sql.Tx) error {
+		query := `DELETE FROM operation_context WHERE id = 1`
+		args := []any{}
+		if flightID != "" {
+			query += ` AND flight_id = ?`
+			args = append(args, flightID)
+		}
+		_, err := tx.ExecContext(ctx, query, args...)
+		return err
+	})
+}
+
+func (w *WAL) applyOperationCommand(ctx context.Context, commandID string, apply func(*sql.Tx) error) (bool, error) {
+	if commandID == "" {
+		return false, errors.New("operation command ID is required")
+	}
+	tx, err := w.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, fmt.Errorf("begin operation command: %w", err)
+	}
+	defer tx.Rollback()
+
+	result, err := tx.ExecContext(ctx, `INSERT OR IGNORE INTO operation_context_commands(command_id, processed_at) VALUES(?, ?)`, commandID, time.Now().UnixNano())
+	if err != nil {
+		return false, fmt.Errorf("record operation command: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("inspect operation command: %w", err)
+	}
+	if rows == 0 {
+		return false, nil
+	}
+	if err := apply(tx); err != nil {
+		return false, fmt.Errorf("apply operation command: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return false, fmt.Errorf("commit operation command: %w", err)
+	}
+	return true, nil
 }
 
 // AppendAsync queues a frame for writing.

--- a/internal/wal/wal_test.go
+++ b/internal/wal/wal_test.go
@@ -257,6 +257,14 @@ func TestWAL_OperationContextPersistsAndCommandsAreIdempotent(t *testing.T) {
 		t.Fatalf("context after reopen = %#v, %v, %v; want %#v", got, ok, err, want)
 	}
 
+	applied, err = w.ClearOperationContext(ctx, "clear-empty", "")
+	if err == nil || applied {
+		t.Fatalf("empty-flight clear = %v, %v; want false, error", applied, err)
+	}
+	if got, ok, err = w.LoadOperationContext(ctx); err != nil || !ok || got != want {
+		t.Fatalf("context after empty-flight clear = %#v, %v, %v; want %#v", got, ok, err, want)
+	}
+
 	applied, err = w.ClearOperationContext(ctx, "clear-old", "another-flight")
 	if err != nil || !applied {
 		t.Fatalf("conditional clear = %v, %v", applied, err)

--- a/internal/wal/wal_test.go
+++ b/internal/wal/wal_test.go
@@ -222,6 +222,57 @@ func TestWAL_MarkDelivered_Idempotency(t *testing.T) {
 	}
 }
 
+func TestWAL_OperationContextPersistsAndCommandsAreIdempotent(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "wal.db")
+	w, err := New(ctx, path, 10, time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := OperationContext{FlightID: "flight-1", IntentID: "intent-1", IntentVersion: 3}
+	applied, err := w.SetOperationContext(ctx, "set-1", want)
+	if err != nil || !applied {
+		t.Fatalf("SetOperationContext() = %v, %v", applied, err)
+	}
+	applied, err = w.SetOperationContext(ctx, "set-1", OperationContext{FlightID: "wrong"})
+	if err != nil || applied {
+		t.Fatalf("duplicate SetOperationContext() = %v, %v", applied, err)
+	}
+	got, ok, err := w.LoadOperationContext(ctx)
+	if err != nil || !ok || got != want {
+		t.Fatalf("LoadOperationContext() = %#v, %v, %v; want %#v", got, ok, err, want)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	w, err = New(ctx, path, 10, time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+	got, ok, err = w.LoadOperationContext(ctx)
+	if err != nil || !ok || got != want {
+		t.Fatalf("context after reopen = %#v, %v, %v; want %#v", got, ok, err, want)
+	}
+
+	applied, err = w.ClearOperationContext(ctx, "clear-old", "another-flight")
+	if err != nil || !applied {
+		t.Fatalf("conditional clear = %v, %v", applied, err)
+	}
+	if got, ok, err = w.LoadOperationContext(ctx); err != nil || !ok || got != want {
+		t.Fatalf("context after mismatched clear = %#v, %v, %v", got, ok, err)
+	}
+	applied, err = w.ClearOperationContext(ctx, "clear-1", want.FlightID)
+	if err != nil || !applied {
+		t.Fatalf("matching clear = %v, %v", applied, err)
+	}
+	if _, ok, err = w.LoadOperationContext(ctx); err != nil || ok {
+		t.Fatalf("context after clear: ok=%v err=%v", ok, err)
+	}
+}
+
 func TestWAL_CleanupDelivered(t *testing.T) {
 	w := mustNewWAL(t)
 	defer w.Close()


### PR DESCRIPTION
## What changed

- persist active flight and intent context in the agent WAL database
- dispatch relay telemetry acknowledgements and set/clear operation commands
- acknowledge operation commands idempotently and protect newer flights from stale clears
- stamp session, flight, intent, and intent version onto telemetry before WAL insertion
- migrate the telemetry stream to the new bidirectional message envelopes

## Why

Telemetry must carry capture-time flight attribution through offline WAL replay, reconnects, and later context changes.

## Validation

- go test ./...
- git diff --check